### PR TITLE
Use Object.prototype.toString instead of global

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -71,7 +71,9 @@
   
   // Utilities
   // Taken from Underscore.js
-  
+
+  var toString = Object.prototype.toString;
+
   var _isObject = function(obj) {
     return obj === Object(obj);
   };


### PR DESCRIPTION
IE 7-10 will throw an 'Invalid calling object' when using the global
toString function. By using Object.prototype.toString (like Underscore),
this error is removed, and allows humps.js to be usable on IE.
