### PR TITLE
Define depascalizeKeys outside of the main humps module definition

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -97,9 +97,10 @@
     },
     pascalizeKeys: function(object) {
       return _processKeys(pascalize, object);
-    },
-    depascalizeKeys: this.decamelizeKeys
+    }
   };
+
+  humps.depascalizeKeys = humps.decamelizeKeys;
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = humps;


### PR DESCRIPTION
Defining depascalizeKeys within the first definition seems to cause issues when run in the browser (using browserify). I simply moved the definition right below the main one, and it seems to work fine.

It would be great if you could merge this in, so I can go back to depending on the upstream repository :smile: 
