### PR TITLE
Fixed negative numbers issue + slightly improved performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-Gemfile.lock
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,3 +17,6 @@ PLATFORMS
 DEPENDENCIES
   jasmine
   rake
+
+BUNDLED WITH
+   1.10.3

--- a/humps.js
+++ b/humps.js
@@ -56,15 +56,13 @@
       return chr ? chr.toUpperCase() : '';
     });
     // Ensure 1st char is always lowercase
-    return string.replace(/^([A-Z])/, function(match, chr) {
-      return chr ? chr.toLowerCase() : '';
-    });
+    return string.substr(0, 1).toLowerCase() + string.substr(1);
   };
 
   var pascalize = function(string) {
-    return camelize(string).replace(/^([a-z])/, function(match, chr) {
-      return chr ? chr.toUpperCase() : '';
-    });
+    var camelized = camelize(string);
+    // Ensure 1st char is always uppercase
+    return camelized.substr(0, 1).toUpperCase() + camelized.substr(1);
   };
 
   var decamelize = function(string, separator) {

--- a/humps.js
+++ b/humps.js
@@ -47,8 +47,7 @@
   };
 
   var camelize = function(string) {
-    // checks if a key is a number
-    if (!_isNaN(string - 0)) {
+    if (_isNumerical(string)) {
       return string;
     }
     string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
@@ -86,12 +85,10 @@
     return toString.call(obj) == '[object RegExp]';
   };
 
-  var _isNaN = function(number) {
-    /**
-     * NaN is the only thing not equal to itself in Javascript.
-     * We can use that to efficiently check whether something is NaN.
-     */
-    return number !== number;
+  // Performant way to determine if obj coerces to a number
+  var _isNumerical = function(obj) {
+    obj = obj - 0;
+    return obj === obj;
   };
 
   var humps = {

--- a/humps.js
+++ b/humps.js
@@ -47,9 +47,8 @@
   };
 
   var camelize = function(string) {
-    // efficiently checks if a key is a number
-    var number = string - 0;
-    if (number === number) {
+    // checks if a key is a number
+    if (!_isNaN(string - 0)) {
       return string;
     }
     string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
@@ -85,6 +84,14 @@
   };
   var _isRegExp = function(obj) {
     return toString.call(obj) == '[object RegExp]';
+  };
+
+  var _isNaN = function(number) {
+    /**
+     * NaN is the only thing not equal to itself in Javascript.
+     * We can use that to efficiently check whether something is NaN.
+     */
+    return number !== number;
   };
 
   var humps = {

--- a/humps.js
+++ b/humps.js
@@ -40,13 +40,18 @@
   // String conversion methods
 
   var separateWords = function(string, separator) {
-    if (separator === undefined) {
+    if (typeof separator === 'undefined') {
       separator = '_';
     }
     return string.replace(/([a-z])([A-Z0-9])/g, '$1'+ separator +'$2');
   };
 
   var camelize = function(string) {
+    // efficiently checks if a key is a number
+    var number = string - 0;
+    if (number === number) {
+      return string;
+    }
     string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
       return chr ? chr.toUpperCase() : '';
     });

--- a/spec/javascripts/humps.spec.js
+++ b/spec/javascripts/humps.spec.js
@@ -120,9 +120,9 @@ describe('humps', function() {
     });
 
     it('converts keys within arrays of objects', function() {
-      var array = [{ first_name: 'Sam' }, { first_name: 'Jenna' }],
-          convertedArray = [{ firstName: 'Sam' }, { firstName: 'Jenna' }],
-          result = humps.camelizeKeys(array);
+      var array = [{first_name: 'Sam'}, {first_name: 'Jenna'}],
+        convertedArray = [{firstName: 'Sam'}, {firstName: 'Jenna'}],
+        result = humps.camelizeKeys(array);
       expect(result).toEqual(convertedArray);
       // Ensure it’s an array, and not an object with numeric keys
       expect(toString.call(result)).toEqual('[object Array]');
@@ -186,6 +186,7 @@ describe('humps', function() {
 
     it('converts hyphenated strings to camelcase', function() {
       expect(humps.camelize('hello-world')).toEqual('helloWorld');
+      expect(humps.camelize('hello-world-1')).toEqual('helloWorld1');
     });
 
     it('converts space-separated strings to camelcase', function() {
@@ -194,6 +195,12 @@ describe('humps', function() {
 
     it('converts PascalCased strings to camelcase', function() {
       expect(humps.camelize('HelloWorld')).toEqual('helloWorld');
+      expect(humps.camelize('HelloWorld')).toEqual('helloWorld');
+    });
+
+    it('keeps numbers unchanged', function() {
+      expect(humps.camelize('-1')).toEqual('-1');
+      expect(humps.camelize('1')).toEqual('1');
     });
   });
 


### PR DESCRIPTION
Hello,

Negative numbers were converted to their absolute values since dash sign was present (and thus removed). It may look hacky but as far as I know it is the most efficient way to check whether string is a number since NaN !== NaN.

I also changed first character conversion to uppercase or lowercase. It uses substr function instead of regexp which makes it a lot faster ([jsPerf](http://jsperf.com/slypotato-replace-vs-substring)). I had a huge object to convert and humps began to hurt.

Tests updated accordingly.
