### PR TITLE
Add option to ignore numbers when separating words

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -11,8 +11,8 @@
 
 ;(function(global) {
 
-  var _processKeys = function(convert, obj, separator) {
-    if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj)) {
+  var _processKeys = function(convert, obj, separator, ignoreNumbers) {
+    if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj) || _isBoolean(obj)) {
       return obj;
     }
 
@@ -23,14 +23,14 @@
     if(_isArray(obj)) {
       output = [];
       for(l=obj.length; i<l; i++) {
-        output.push(_processKeys(convert, obj[i], separator));
+        output.push(_processKeys(convert, obj[i], separator, ignoreNumbers));
       }
     }
     else {
       output = {};
       for(var key in obj) {
         if(obj.hasOwnProperty(key)) {
-          output[convert(key, separator)] = _processKeys(convert, obj[key], separator);
+          output[convert(key, separator, ignoreNumbers)] = _processKeys(convert, obj[key], separator, ignoreNumbers);
         }
       }
     }
@@ -39,11 +39,18 @@
 
   // String conversion methods
 
-  var separateWords = function(string, separator) {
+  var separateWords = function(string, separator, ignoreNumbers) {
     if (typeof separator === 'undefined') {
       separator = '_';
     }
-    return string.replace(/([a-z])([A-Z0-9])/g, '$1'+ separator +'$2');
+
+    var regexp = /([a-z])([A-Z0-9])/g;
+
+    if (ignoreNumbers) {
+      regexp = /([a-z])([A-Z])/g;
+    }
+
+    return string.replace(regexp, '$1'+ separator +'$2');
   };
 
   var camelize = function(string) {
@@ -63,8 +70,8 @@
     return camelized.substr(0, 1).toUpperCase() + camelized.substr(1);
   };
 
-  var decamelize = function(string, separator) {
-    return separateWords(string, separator).toLowerCase();
+  var decamelize = function(string, separator, ignoreNumbers) {
+    return separateWords(string, separator, ignoreNumbers).toLowerCase();
   };
 
   // Utilities
@@ -84,6 +91,9 @@
   var _isRegExp = function(obj) {
     return toString.call(obj) == '[object RegExp]';
   };
+  var _isBoolean = function(obj) {
+    return toString.call(obj) == '[object Boolean]';
+  };
 
   // Performant way to determine if obj coerces to a number
   var _isNumerical = function(obj) {
@@ -99,8 +109,8 @@
     camelizeKeys: function(object) {
       return _processKeys(camelize, object);
     },
-    decamelizeKeys: function(object, separator) {
-      return _processKeys(decamelize, object, separator);
+    decamelizeKeys: function(object, separator, ignoreNumbers) {
+      return _processKeys(decamelize, object, separator, ignoreNumbers);
     },
     pascalizeKeys: function(object) {
       return _processKeys(pascalize, object);

--- a/spec/javascripts/humps.spec.js
+++ b/spec/javascripts/humps.spec.js
@@ -75,6 +75,24 @@ describe('humps', function() {
       }
     };
 
+    this.complexIgnoringNumbersObj = {
+      attr_one: 'foo',
+      attr_two: {
+        nested_attr1: 'bar'
+      },
+      attr_three: {
+        nested_attr2: {
+          nested_attr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    };
+
     this.complexCustomObj = {
       'attr-one': 'foo',
       'attr-two': {
@@ -141,6 +159,10 @@ describe('humps', function() {
     it('decamelizes keys with a custom separator', function() {
       expect(humps.decamelizeKeys(this.complexCamelObj, '-')).toEqual(this.complexCustomObj);
     });
+
+    it('decamelizes keys ignoring numbers', function() {
+      expect(humps.decamelizeKeys(this.complexCamelObj, '_', true)).toEqual(this.complexIgnoringNumbersObj);
+    });
   });
 
   describe('.pascalizeKeys', function() {
@@ -177,6 +199,10 @@ describe('humps', function() {
     it('depascalizes keys with a custom separator', function() {
       expect(humps.depascalizeKeys(this.complexPascalObj, '-')).toEqual(this.complexCustomObj);
     });
+
+    it('depascalizes keys ignoring numbers', function() {
+      expect(humps.depascalizeKeys(this.complexPascalObj, '_', true)).toEqual(this.complexIgnoringNumbersObj);
+    });
   });
 
   describe('.camelize', function() {
@@ -211,6 +237,10 @@ describe('humps', function() {
 
     it('decamelizes strings with custom separator', function() {
       expect(humps.decamelize('helloWorld', '-')).toEqual('hello-world');
+    });
+
+    it('decamelizes strings ignoring numbers', function() {
+      expect(humps.decamelize('helloWorld1', '_', true)).toEqual('hello_world1');
     });
   });
 


### PR DESCRIPTION
My API server doesn't underscore on integers, so this is problematic when I'm trying to `decamelize` the entire payload. I've added a 3rd option to `decamelize` which is an ignoreNumbers boolean flag. If set to true, it'll ignore numbers when decamelizing.

I'm not 100% sure on the API, since it's the 3rd argument and so it'd require you define a separator, but it is backwards compatible at least.