### PR TITLE
Exclude from camelization all-uppercase keys

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -47,7 +47,7 @@
   };
 
   var camelize = function(string) {
-    if (_isNumerical(string)) {
+    if (_isNumerical(string) || _isUpperCase(string)) {
       return string;
     }
     string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
@@ -64,6 +64,9 @@
   };
 
   var decamelize = function(string, options) {
+    if( _isUpperCase(string) ) {
+      return string;
+    }
     return separateWords(string, options).toLowerCase();
   };
 
@@ -93,6 +96,10 @@
     obj = obj - 0;
     return obj === obj;
   };
+
+  var _isUpperCase = function(obj) {
+    return obj.toUpperCase()==obj;
+  }
 
   var humps = {
     camelize: camelize,

--- a/test/test.js
+++ b/test/test.js
@@ -12,17 +12,20 @@ describe('humps', function() {
   beforeEach(function() {
     this.simple_obj = {
       attr_one: 'foo',
-      attr_two: 'bar'
+      attr_two: 'bar',
+      ATTRTHREE: 'buzz'
     };
 
     this.simpleCamelObj = {
       attrOne: 'foo',
-      attrTwo: 'bar'
+      attrTwo: 'bar',
+      ATTRTHREE: 'buzz'
     };
 
     this.simplePascalObj = {
       AttrOne: 'foo',
-      AttrTwo: 'bar'
+      AttrTwo: 'bar',
+      ATTRTHREE: 'buzz'
     };
 
     this.complex_obj = {


### PR DESCRIPTION
I do believe that all-uppercase keys should not be camelized, as they probably are acronyms. 

Think for example to keys like "ID" or "UUID": if camelized, they do became "iD" and "uUID" respectively. 