### PR TITLE
#22 - Keep underscore prefix unchanged

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -51,7 +51,7 @@
       return string;
     }
     string = string.replace(/[\-_\s]+(.)?/g, function(match, chr, offset) {
-      return chr && offset ? chr.toUpperCase() : (offset ? '' : match);
+      return chr && offset ? chr.toUpperCase() : (offset && chr ? '' : match);
     });
     // Ensure 1st char is always lowercase
     return string.substr(0, 1).toLowerCase() + string.substr(1);

--- a/humps.js
+++ b/humps.js
@@ -50,8 +50,8 @@
     if (_isNumerical(string)) {
       return string;
     }
-    string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
-      return chr ? chr.toUpperCase() : '';
+    string = string.replace(/[\-_\s]+(.)?/g, function(match, chr, offset) {
+      return chr && offset ? chr.toUpperCase() : (offset ? '' : match);
     });
     // Ensure 1st char is always lowercase
     return string.substr(0, 1).toLowerCase() + string.substr(1);

--- a/test/test.js
+++ b/test/test.js
@@ -235,6 +235,11 @@ describe('humps', function() {
       assert.equal(humps.camelize('_hello_world'), '_helloWorld');
       assert.equal(humps.camelize('__hello_world'), '__helloWorld');
     });
+
+    it('keeps underscore suffix unchanged', function() {
+      assert.equal(humps.camelize('_hello_world_'), '_helloWorld_');
+      assert.equal(humps.camelize('__hello_world_'), '__helloWorld_');
+    });
   });
 
   describe('.decamelize', function() {
@@ -259,6 +264,11 @@ describe('humps', function() {
     it('keeps underscore prefix unchanged', function() {
       assert.equal(humps.decamelize('_helloWorld'), '_hello_world');
       assert.equal(humps.decamelize('__helloWorld'), '__hello_world');
+    });
+
+    it('keeps underscore suffix unchanged', function() {
+      assert.equal(humps.decamelize('_helloWorld_'), '_hello_world_');
+      assert.equal(humps.decamelize('__helloWorld_'), '__hello_world_');
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -230,6 +230,11 @@ describe('humps', function() {
       assert.equal(humps.camelize('-1'), '-1');
       assert.equal(humps.camelize('1'), '1');
     });
+
+    it('keeps underscore prefix unchanged', function() {
+      assert.equal(humps.camelize('_hello_world'), '_helloWorld');
+      assert.equal(humps.camelize('__hello_world'), '__helloWorld');
+    });
   });
 
   describe('.decamelize', function() {
@@ -249,6 +254,11 @@ describe('humps', function() {
     it('uses a custom split regexp', function() {
       assert.equal(humps.decamelize('helloWorld1', { split: /(?=[A-Z0-9])/ }),
         'hello_world_1');
+    });
+
+    it('keeps underscore prefix unchanged', function() {
+      assert.equal(humps.decamelize('_helloWorld'), '_hello_world');
+      assert.equal(humps.decamelize('__helloWorld'), '__hello_world');
     });
   });
 


### PR DESCRIPTION
Names starting with underscore can not be camelized and then decamelized back safely. I ran into this issue with an API I am using that has keys like this `{_embedded: [...]}`.

This should resolve #22.