### PR TITLE
Add ability to exclude certain keys from processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ humps.decamelize('helloWorld1', { split: /(?=[A-Z0-9])/ }) // 'hello_world_1'
 
 Same as `humps.decamelize` above.
 
-### `humps.camelizeKeys(object)`
+### `humps.camelizeKeys(object, options)`
 
 Converts object keys to camelCase. It also converts arrays of objects.
 
-### `humps.pascalizeKeys(object)`
+Available options:
+  - keyExclusions (Array): An array of keys, which will be excluded from the camelization process.
+  - parentKeyExclusions (Array): An array of keys, who's child keys will be excluded from the camelization process.
+
+### `humps.pascalizeKeys(object, options)`
 
 Converts object keys to PascalCase. It also converts arrays of objects.
 

--- a/humps.js
+++ b/humps.js
@@ -10,7 +10,7 @@
 
 ;(function(global) {
 
-  var _processKeys = function(convert, obj, options) {
+  var _processKeys = function(convert, obj, options, parentKeyExcluded) {
     if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj) || _isBoolean(obj)) {
       return obj;
     }
@@ -18,6 +18,9 @@
     var output,
         i = 0,
         l = 0;
+
+    var keyExclusions = options && options.keyExclusions || [];
+    var parentKeyExclusions = options && options.parentKeyExclusions || [];
 
     if(_isArray(obj)) {
       output = [];
@@ -27,9 +30,18 @@
     }
     else {
       output = {};
+      var excludeKey = parentKeyExcluded;
+
       for(var key in obj) {
-        if(obj.hasOwnProperty(key)) {
-          output[convert(key, options)] = _processKeys(convert, obj[key], options);
+        var parentKeyExcluded =
+          parentKeyExclusions.indexOf(key) !== -1 ? true : false;
+
+        if(obj.hasOwnProperty(key)
+            && keyExclusions.indexOf(key) === -1
+            && !excludeKey) {
+          output[convert(key, options)] = _processKeys(convert, obj[key], options, parentKeyExcluded);
+        } else {
+          output[key] = _processKeys(convert, obj[key], options, parentKeyExcluded);
         }
       }
     }
@@ -99,14 +111,14 @@
     decamelize: decamelize,
     pascalize: pascalize,
     depascalize: decamelize,
-    camelizeKeys: function(object) {
-      return _processKeys(camelize, object);
+    camelizeKeys: function(object, options) {
+      return _processKeys(camelize, object, options);
     },
     decamelizeKeys: function(object, options) {
       return _processKeys(decamelize, object, options);
     },
-    pascalizeKeys: function(object) {
-      return _processKeys(pascalize, object);
+    pascalizeKeys: function(object, options) {
+      return _processKeys(pascalize, object, options);
     },
     depascalizeKeys: function () {
       return this.decamelizeKeys.apply(this, arguments);

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,25 @@ describe('humps', function() {
       }
     };
 
+     this.complex_obj_exclude = {
+      attr_one: 'foo',
+      attr_two: {
+        nested_attr1: 'bar'
+      },
+      attr_three: {
+        nested_attr2: {
+          nested_attr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        },
+        nested_attr4: 'foo'
+      }
+    };
+
     this.complexCamelObj = {
       attrOne: 'foo',
       attrTwo: {
@@ -76,6 +95,25 @@ describe('humps', function() {
             NestedInArray3: ['world', 'boo']
           }]
         }
+      }
+    };
+
+    this.complexPascalObjExclude = {
+      AttrOne: 'foo',
+      AttrTwo: {
+        NestedAttr1: 'bar'
+      },
+      AttrThree: {
+        nested_attr2: {
+          NestedAttr3: [{
+            NestedInArray1: 'baz'
+          }, {
+            NestedInArray2: 'hello'
+          }, {
+            NestedInArray3: ['world', 'boo']
+          }]
+        },
+        nested_attr4: 'foo'
       }
     };
 
@@ -114,6 +152,25 @@ describe('humps', function() {
         }
       }
     };
+
+    this.complexCamelObjExclude = {
+      attrOne: 'foo',
+      attrTwo: {
+        nestedAttr1: 'bar'
+      },
+      attrThree: {
+        nested_attr2: {
+          nestedAttr3: [{
+            nestedInArray1: 'baz'
+          }, {
+            nestedInArray2: 'hello'
+          }, {
+            nestedInArray3: ['world', 'boo']
+          }]
+        },
+        nested_attr4: 'foo'
+      }
+    };
   });
 
   // =========
@@ -127,6 +184,18 @@ describe('humps', function() {
 
     it('converts complex object keys to camelcase', function() {
       assert.deepEqual(humps.camelizeKeys(this.complex_obj), this.complexCamelObj);
+    });
+
+    it('converts complex object to camelcase, excluding given keys ', function() {
+      assert.deepEqual(humps.camelizeKeys(this.complex_obj_exclude, {
+        keyExclusions: ['nested_attr2', 'nested_attr4']
+      }), this.complexCamelObjExclude);
+    });
+
+    it('converts complex object to camelcase, excluding child keys of given keys', function() {
+      assert.deepEqual(humps.camelizeKeys(this.complex_obj_exclude, {
+        parentKeyExclusions: ['attr_three']
+      }), this.complexCamelObjExclude);
     });
 
     it('does not attempt to process dates', function() {
@@ -179,6 +248,19 @@ describe('humps', function() {
     it('converts complex object keys to PascalCase', function() {
       assert.deepEqual(humps.pascalizeKeys(this.complex_obj), this.complexPascalObj);
     });
+
+    it('converts complex object to PascalCase, excluding given keys ', function() {
+      assert.deepEqual(humps.pascalizeKeys(this.complex_obj_exclude, {
+        keyExclusions: ['nested_attr2', 'nested_attr4']
+      }), this.complexPascalObjExclude);
+    });
+
+    it('converts complex object to PascalCase, excluding child keys of given keys', function() {
+      assert.deepEqual(humps.pascalizeKeys(this.complex_obj_exclude, {
+        parentKeyExclusions: ['attr_three']
+      }), this.complexPascalObjExclude);
+    });
+
 
     it('does not attempt to process dates', function() {
       'work in progress';


### PR DESCRIPTION
In some cases we don't want specific keys to be processed. Also, in
more advanced scenarios we might not want arbitrary keys that are a
child of some other key (that is predetermined) to be processed.