### PR TITLE
Added check that options is an object

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -97,7 +97,7 @@
   // Sets up function which handles processing keys
   // allowing the convert function to be modified by a callback
   var _processor = function(convert, options) {
-    var callback = options && 'process' in options ? options.process : options;
+    var callback = options && _isObject(options) && 'process' in options ? options.process : options;
 
     if(typeof(callback) !== 'function') {
       return convert;


### PR DESCRIPTION
The motivation for this is that humps' functions may be used as a callback in a ```map```, ```forEach``` (or similar), and if the second argument is not an object, the ```'process' in options ? ...``` check will throw an error.