### PR TITLE
Replace direct call to .hasOwnProperty() builtin

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -28,7 +28,7 @@
     else {
       output = {};
       for(var key in obj) {
-        if(obj.hasOwnProperty(key)) {
+        if(Object.prototype.hasOwnProperty.call(obj, key)) {
           output[convert(key, options)] = _processKeys(convert, obj[key], options);
         }
       }


### PR DESCRIPTION
Since js doesn't protect the hasOwnProperty property of objects, switch to calling the method from the Object prototype.

See also: http://eslint.org/docs/rules/no-prototype-builtins