### PR TITLE
`plainOnly` feature

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -24,6 +24,8 @@
       for(l=obj.length; i<l; i++) {
         output.push(_processKeys(convert, obj[i], options));
       }
+    } else if(_isObject(options) && options.plainOnly && !_isPlainObject(obj)) {
+      return obj;
     }
     else {
       output = {};
@@ -77,6 +79,9 @@
   };
   var _isObject = function(obj) {
     return obj === Object(obj);
+  };
+  var _isPlainObject = function(obj) {
+    return Object.getPrototypeOf(obj) === Object.prototype;
   };
   var _isArray = function(obj) {
     return toString.call(obj) == '[object Array]';

--- a/test/test.js
+++ b/test/test.js
@@ -114,6 +114,20 @@ describe('humps', function() {
         }
       }
     };
+
+    this.complicated_object = {
+      attr_one: 'foo',
+      attr_two: new (function() {
+        this.attr_three = 'bar';
+      })
+    };
+
+    this.complicatedObject = {
+      attrOne: 'foo',
+      attrTwo: new (function() {
+        this.attrThree = 'bar';
+      })
+    };
   });
 
   // =========
@@ -219,6 +233,17 @@ describe('humps', function() {
         }
       });
       assert.deepEqual(actual, { attrOne: 'foo', attr_two: 'bar' });
+    });
+
+    it('converts complicated objects with camelcased keys to underscored', function() {
+      assert.deepEqual(humps.decamelizeKeys(this.complicatedObject), this.complicated_object);
+    });
+
+    it('skip complicated objects with `plainOnly` option', function() {
+      assert.deepEqual(
+        humps.decamelizeKeys(this.complicatedObject, { plainOnly: true }).attr_two,
+        this.complicatedObject.attrTwo
+      );
     });
   });
 


### PR DESCRIPTION
This option is prevent to change keys in non-plain objects.
For example: this breaks Moment.js object, with this option - all ok.