### PR TITLE
Added fix for prototype.js > 1.7.3

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -79,7 +79,7 @@
     return obj === Object(obj);
   };
   var _isArray = function(obj) {
-    return toString.call(obj) == '[object Array]';
+    return  'isArray' in Array ? Array.isArray(obj) : toString.call(obj) == '[object Array]';
   };
   var _isDate = function(obj) {
     return toString.call(obj) == '[object Date]';


### PR DESCRIPTION
I was having an issue where an Array was being turned into an Object when using humps.decamilzeKeys()

We are currently running on a prototypes.js version 1.5. Anything lower then 1.7.3 will be affected with this type checking error.

Please see last comment in issue https://github.com/jquery/jquery/issues/3553