### PR TITLE
Does not attemp to process `File`

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -11,7 +11,7 @@
 ;(function(global) {
 
   var _processKeys = function(convert, obj, options) {
-    if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj) || _isBoolean(obj) || _isFunction(obj)) {
+    if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj) || _isBoolean(obj) || _isFunction(obj) || _isFile(obj)) {
       return obj;
     }
 
@@ -89,6 +89,9 @@
   };
   var _isBoolean = function(obj) {
     return toString.call(obj) == '[object Boolean]';
+  };
+  var _isFile = function(obj) {
+    return toString.call(obj) == '[object File]';
   };
 
   // Performant way to determine if obj coerces to a number


### PR DESCRIPTION
This pull request makes it not attempt to process `File` object.
I tried to add tests like this,

```js
it('does not attempt to process files', function() {
  var file = new File([], '');
  var _object = {
    a_file: file
  };
  var convertedObject = {
    aFile: file
  };
  assert.deepEqual(humps.camelizeKeys(_object), convertedObject);
});
```

but I got this error

```
ReferenceError: File is not defined
```

This doesn't concern my changes and I didn't know how to solve it.
So I'm just opening a pull request.