### PR TITLE
Add depth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,37 +12,47 @@ Usage
 
 ### Converting strings
 
-    humps.camelize('hello_world') // 'helloWorld'
-    humps.decamelize('fooBar') // 'foo_bar'
-    humps.decamelize('fooBarBaz', { separator: '-' }) // 'foo-bar-baz'
+```js
+humps.camelize('hello_world') // 'helloWorld'
+humps.decamelize('fooBar') // 'foo_bar'
+humps.decamelize('fooBarBaz', { separator: '-' }) // 'foo-bar-baz'
+```
 
 ### Converting object keys
 
-    var object = { attr_one: 'foo', attr_two: 'bar' }
-    humps.camelizeKeys(object); // { attrOne: 'foo', attrTwo: 'bar' }
+```js
+var object = { attr_one: 'foo', attr_two: 'bar' }
+humps.camelizeKeys(object); // { attrOne: 'foo', attrTwo: 'bar' }
+```
 
 Arrays of objects are also converted
 
-    var array = [{ attr_one: 'foo' }, { attr_one: 'bar' }]
-    humps.camelizeKeys(array); // [{ attrOne: 'foo' }, { attrOne: 'bar' }]
+```js
+var array = [{ attr_one: 'foo' }, { attr_one: 'bar' }]
+humps.camelizeKeys(array); // [{ attrOne: 'foo' }, { attrOne: 'bar' }]
+```
 
 It also accepts a callback which can modify the conversion behavior. For example to prevent conversion of keys containing only uppercase letters or numbers:
 
-    humps.camelizeKeys(obj, function (key, convert) {
-      return /^[A-Z0-9_]+$/.test(key) ? key : convert(key);
-    });
-    humps.decamelizeKeys(obj, function (key, convert, options) {
-      return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
-    });
+```js
+humps.camelizeKeys(obj, function(key, convert) {
+  return /^[A-Z0-9_]+$/.test(key) ? key : convert(key);
+});
+humps.decamelizeKeys(obj, function(key, convert, options) {
+  return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
+});
+```
 
 In order to use the callback with options use the `process` option:
 
-    humps.decamelizeKeys(obj, {
-        separator: '-',
-        process: function (key, convert, options) {
-          return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
-        }
-    });
+```js
+humps.decamelizeKeys(obj, {
+    separator: '-',
+    process: function(key, convert, options) {
+      return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
+    }
+});
+```
 
 API
 ---
@@ -51,57 +61,84 @@ API
 
 Removes any hypens, underscores, and whitespace characters, and uppercases the first character that follows.
 
-```javascript
+```js
 humps.camelize('hello_world-foo bar') // 'helloWorldFooBar'
 ```
 
 ### `humps.pascalize(string)`
 
-Similar to `humps.camelize(string)`, but also ensures that the first character is uppercase.
+Similar to `humps.camelize`, but also ensures that the first character is uppercase.
 
-```javascript
+```js
 humps.pascalize('hello_world-foo bar') // 'HelloWorldFooBar'
 ```
 
-### `humps.decamelize(string, options)`
+### `humps.decamelize(string[, options])`
 
 Converts camelCased string to an underscore-separated string.
 
-```javascript
+Properties of the optional `options` object:
+
+| Property    | Description                       | Type   | Default         |
+|-------------|-----------------------------------|--------|-----------------|
+| `separator` | Customizes the separator          | String | `'-'`           |
+| `split`     | Customizes the splitting strategy | RegExp | ``/(?=[A-Z])/`` |
+
+
+```js
 humps.decamelize('helloWorldFooBar') // 'hello_world_foo_bar'
 ```
 
 The separator can be customized with the `separator` option.
 
-```javascript
+```js
 humps.decamelize('helloWorldFooBar', { separator: '-' }) // 'hello-world-foo-bar'
 ```
 
-By default, `decamelize` will only split words on capital letters (not numbers as in humps pre v1.0). To customize this behaviour, use the `split` option. This should be a regular expression which, when passed into `String.prototype.split`, produces an array of words (by default the regular expression is: `/(?=[A-Z])/`). For example, to treat numbers as uppercase:
+By default, `humps.decamelize` will only split words on capital letters (not numbers as in humps pre v1.0). To customize this behaviour, use the `split` option. This should be a regular expression which, when passed into `String.prototype.split`, produces an array of words. For example, to treat numbers as uppercase:
 
-```javascript
+```js
 humps.decamelize('helloWorld1', { split: /(?=[A-Z0-9])/ }) // 'hello_world_1'
 ```
 
-### `humps.depascalize(string, options)`
+### `humps.depascalize(string[, options])`
 
 Same as `humps.decamelize` above.
 
-### `humps.camelizeKeys(object, options)`
+### `humps.camelizeKeys(object[, options])`
 
 Converts object keys to camelCase. It also converts arrays of objects.
 
-### `humps.pascalizeKeys(object, options)`
+Properties of the optional `options` object:
 
-Converts object keys to PascalCase. It also converts arrays of objects.
+| Property | Description | Type | Default |
+|-|-|-|-|
+| `process` | Modifies the conversion behavior. See example in Usage section. | Function | Convert the key no matter what |
+| `depth` | How many levels deep in a nested object that keys will be converted. Any number `<= 0` will result in a completely unchanged object. | Number | `undefined` (all keys will be converted) |
 
-### `humps.decamelizeKeys(object, options)`
+### `humps.pascalizeKeys(object[, options])`
 
-Separates camelCased object keys with an underscore. It also converts arrays of objects. See `humps.decamelize` for details of options.
+Similar to `humps.camelizeKeys`, but also ensures that the first character of the key is uppercase.
 
-### `humps.depascalizeKeys(object, options)`
+### `humps.decamelizeKeys(object[, options])`
 
-See `humps.decamelizeKeys`.
+Separates camelCased object keys with an underscore. It also converts arrays of objects.
+
+Properties of the optional `options` object:
+
+| Property | Description | Type | Default |
+|-|-|-|-|
+| `separator` | Customizes the separator | String | `'-'` |
+| `split`     | Customizes the splitting strategy | RegExp | ``/(?=[A-Z])/`` |
+| `process` | Modifies the conversion behavior. See example in Usage section. | Function | Convert the key no matter what |
+| `depth` | How many levels deep in a nested object that keys will be converted. Any number `<= 0` will result in a completely unchanged object. | Number | `undefined` (all keys will be converted) |
+
+
+See `humps.decamelize` for examples.
+
+### `humps.depascalizeKeys(object[, options])`
+
+Same as `humps.decamelizeKeys`.
 
 Licence
 -------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humps",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Underscore-to-camelCase converter (and vice versa) for strings and object keys in JavaScript.",
   "main": "humps.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -265,15 +265,15 @@ describe('humps', function() {
 
   describe('.camelizeKeys', function() {
     it('converts simple object keys to camelcase', function() {
-      assert.deepStrictEqual(humps.camelizeKeys(simple_obj), simpleCamelObj);
+      assert.deepEqual(humps.camelizeKeys(simple_obj), simpleCamelObj);
     });
 
     it('converts complex object keys to camelcase', function() {
-      assert.deepStrictEqual(humps.camelizeKeys(complex_obj), complexCamelObj);
+      assert.deepEqual(humps.camelizeKeys(complex_obj), complexCamelObj);
     });
 
     it('converts complex object keys to camelcase', function() {
-      assert.deepStrictEqual(humps.camelizeKeys(complex_obj), complexCamelObj);
+      assert.deepEqual(humps.camelizeKeys(complex_obj), complexCamelObj);
     });
 
     it('does not attempt to process dates', function() {
@@ -285,23 +285,23 @@ describe('humps', function() {
       var convertedObject = {
         aDate: date
       };
-      assert.deepStrictEqual(humps.camelizeKeys(_object), convertedObject);
+      assert.deepEqual(humps.camelizeKeys(_object), convertedObject);
     });
 
     it('converts keys within arrays of objects', function() {
       var array = [{first_name: 'Sam'}, {first_name: 'Jenna'}],
         convertedArray = [{firstName: 'Sam'}, {firstName: 'Jenna'}],
         result = humps.camelizeKeys(array);
-      assert.deepStrictEqual(result, convertedArray);
+      assert.deepEqual(result, convertedArray);
       // Ensure it’s an array, and not an object with numeric keys
-      assert.deepStrictEqual(toString.call(result), '[object Array]');
+      assert.deepEqual(toString.call(result), '[object Array]');
     });
 
     it('uses a custom conversion callback', function() {
       var result = humps.camelizeKeys(simple_obj, function(key, convert) {
         return key === 'attr_one' ? key : convert(key);
       });
-      assert.deepStrictEqual(result, { attr_one: 'foo', attrTwo: 'bar' });
+      assert.deepEqual(result, { attr_one: 'foo', attrTwo: 'bar' });
     });
 
     describe("when the value is a function", function() {
@@ -313,21 +313,21 @@ describe('humps', function() {
         };
 
         var result = humps.camelizeKeys(_object);
-        assert.deepStrictEqual(result.aFunction, myFunction);
+        assert.deepEqual(result.aFunction, myFunction);
       });
     });
 
     describe("when the depth option is provided", function() {
       describe("and it is less than 1", function() {
         it('does not convert anything given a depth of -1', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.camelizeKeys(complex_obj, { depth: -1 }),
             complex_obj
           );
         });
 
         it('does not convert anything given a depth of 0', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.camelizeKeys(complex_obj, { depth: 0 }),
             complex_obj
           );
@@ -335,28 +335,28 @@ describe('humps', function() {
       });
 
       it('converts keys only on the top level', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.camelizeKeys(complex_obj, { depth: 1 }),
           complexObjCamelizedOneLevelDeep
         );
       });
 
       it('converts keys two levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.camelizeKeys(complex_obj, { depth: 2 }),
           complexObjCamelizedTwoLevelsDeep
         );
       });
 
       it('converts keys three levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.camelizeKeys(complex_obj, { depth: 3 }),
           complexObjCamelizedThreeLevelsDeep
         );
       });
 
       it('converts keys in the entire object four levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.camelizeKeys(complex_obj, { depth: 4 }),
           complexCamelObj
         );
@@ -366,28 +366,28 @@ describe('humps', function() {
 
   describe('.decamelizeKeys', function() {
     it('converts simple objects with camelcased keys to underscored', function() {
-      assert.deepStrictEqual(humps.decamelizeKeys(simpleCamelObj), simple_obj);
+      assert.deepEqual(humps.decamelizeKeys(simpleCamelObj), simple_obj);
     });
 
     it('converts complex objects with camelcased keys to underscored', function() {
-      assert.deepStrictEqual(humps.decamelizeKeys(complexCamelObj), complex_obj);
+      assert.deepEqual(humps.decamelizeKeys(complexCamelObj), complex_obj);
     });
 
     it('decamelizes keys with a custom separator', function() {
       var result = humps.decamelizeKeys(complexCamelObj, { separator: '-' });
-      assert.deepStrictEqual(result, complexCustomObj);
+      assert.deepEqual(result, complexCustomObj);
     });
 
     it('uses a custom split regexp', function() {
       var result = humps.decamelizeKeys({ attr1: 'foo' }, { split: /(?=[A-Z0-9])/ });
-      assert.deepStrictEqual(result, { attr_1: 'foo' });
+      assert.deepEqual(result, { attr_1: 'foo' });
     });
 
     it('uses a custom conversion callback', function() {
       var result = humps.decamelizeKeys(simpleCamelObj, function(key, convert, options) {
         return key === 'attrOne' ? key : convert(key, options);
       });
-      assert.deepStrictEqual(result, { attrOne: 'foo', attr_two: 'bar' });
+      assert.deepEqual(result, { attrOne: 'foo', attr_two: 'bar' });
     });
 
     it('uses a custom conversion callback as an option', function() {
@@ -396,7 +396,7 @@ describe('humps', function() {
           return key === 'attrOne' ? key : convert(key, options);
         }
       });
-      assert.deepStrictEqual(result, { attrOne: 'foo', attr_two: 'bar' });
+      assert.deepEqual(result, { attrOne: 'foo', attr_two: 'bar' });
     });
 
     describe("when the value is a function", function() {
@@ -408,21 +408,21 @@ describe('humps', function() {
         };
 
         var result = humps.decamelizeKeys(_object);
-        assert.deepStrictEqual(result.a_function, myFunction);
+        assert.deepEqual(result.a_function, myFunction);
       });
     });
 
     describe("when the depth option is provided", function() {
       describe("and it is less than 1", function() {
         it('does not convert anything given a depth of -1', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.decamelizeKeys(complexCamelObj, { depth: -1 }),
             complexCamelObj
           );
         });
 
         it('does not convert anything given a depth of 0', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.decamelizeKeys(complexCamelObj, { depth: 0 }),
             complexCamelObj
           );
@@ -430,35 +430,35 @@ describe('humps', function() {
       });
 
       it('converts keys only on the top level', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.decamelizeKeys(complexCamelObj, { depth: 1 }),
           complex_obj_decamelized_one_level_deep
         );
       });
 
       it('converts keys two levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.decamelizeKeys(complexCamelObj, { depth: 2 }),
           complex_obj_decamelized_two_levels_deep
         );
       });
 
       it('converts keys three levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.decamelizeKeys(complexCamelObj, { depth: 3 }),
           complex_obj_decamelized_three_levels_deep
         );
       });
 
       it('converts keys in the entire object four levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.decamelizeKeys(complexCamelObj, { depth: 4 }),
           complex_obj
         );
       });
 
       it('converts keys in the entire custom object four levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.decamelizeKeys(complexCamelObj, { depth: 4, separator: '-' }),
           complexCustomObj
         );
@@ -471,18 +471,18 @@ describe('humps', function() {
             return key === 'attrOne' ? key : convert(key, options);
           }
         });
-        assert.deepStrictEqual(result, { attrOne: 'foo', attr_two: 'bar' });
+        assert.deepEqual(result, { attrOne: 'foo', attr_two: 'bar' });
       });
     });
   });
 
   describe('.pascalizeKeys', function() {
     it('converts simple object keys to PascalCase', function() {
-      assert.deepStrictEqual(humps.pascalizeKeys(simple_obj), simplePascalObj);
+      assert.deepEqual(humps.pascalizeKeys(simple_obj), simplePascalObj);
     });
 
     it('converts complex object keys to PascalCase', function() {
-      assert.deepStrictEqual(humps.pascalizeKeys(complex_obj), complexPascalObj);
+      assert.deepEqual(humps.pascalizeKeys(complex_obj), complexPascalObj);
     });
 
     it('does not attempt to process dates', function() {
@@ -494,27 +494,27 @@ describe('humps', function() {
       var convertedObject = {
         ADate: date
       };
-      assert.deepStrictEqual(humps.pascalizeKeys(_object), convertedObject);
+      assert.deepEqual(humps.pascalizeKeys(_object), convertedObject);
     });
 
     it('uses a custom conversion callback', function() {
       var result = humps.pascalizeKeys(simple_obj, function(key, convert) {
         return key === 'attr_one' ? key : convert(key);
       });
-      assert.deepStrictEqual(result, { attr_one: 'foo', AttrTwo: 'bar' });
+      assert.deepEqual(result, { attr_one: 'foo', AttrTwo: 'bar' });
     });
 
     describe("when the depth option is provided", function() {
       describe("and it is less than 1", function() {
         it('does not convert anything given a depth of -1', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.pascalizeKeys(complex_obj, { depth: -1 }),
             complex_obj
           );
         });
 
         it('does not convert anything given a depth of 0', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.pascalizeKeys(complex_obj, { depth: 0 }),
             complex_obj
           );
@@ -522,28 +522,28 @@ describe('humps', function() {
       });
 
       it('converts keys only on the top level', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.pascalizeKeys(complex_obj, { depth: 1 }),
           complexObjPascalizedOneLevelDeep
         );
       });
 
       it('converts keys two levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.pascalizeKeys(complex_obj, { depth: 2 }),
           complexObjPascalizedTwoLevelsDeep
         );
       });
 
       it('converts keys three levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.pascalizeKeys(complex_obj, { depth: 3 }),
           complexObjPascalizedThreeLevelsDeep
         );
       });
 
       it('converts keys in the entire object four levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.pascalizeKeys(complex_obj, { depth: 4 }),
           complexPascalObj
         );
@@ -553,29 +553,29 @@ describe('humps', function() {
 
   describe('.depascalizeKeys', function() {
     it('converts simple object with PascalCase keys to underscored', function() {
-      assert.deepStrictEqual(humps.depascalizeKeys(simplePascalObj), simple_obj);
+      assert.deepEqual(humps.depascalizeKeys(simplePascalObj), simple_obj);
     });
 
     it('converts complex object with PascalCase keys to underscored', function() {
-      assert.deepStrictEqual(humps.depascalizeKeys(complexPascalObj), complex_obj);
+      assert.deepEqual(humps.depascalizeKeys(complexPascalObj), complex_obj);
     });
 
     it('depascalizes keys with a custom separator', function() {
       var result = humps.depascalizeKeys(complexPascalObj, { separator: '-' });
-      assert.deepStrictEqual(result, complexCustomObj);
+      assert.deepEqual(result, complexCustomObj);
     });
 
     describe("when the depth option is provided", function() {
       describe("and it is less than 1", function() {
         it('does not convert anything given a depth of -1', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.depascalizeKeys(complexCamelObj, { depth: -1 }),
             complexCamelObj
           );
         });
 
         it('does not convert anything given a depth of 0', function() {
-          assert.deepStrictEqual(
+          assert.deepEqual(
             humps.depascalizeKeys(complexCamelObj, { depth: 0 }),
             complexCamelObj
           );
@@ -583,28 +583,28 @@ describe('humps', function() {
       });
 
       it('converts keys only on the top level', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.depascalizeKeys(complexCamelObj, { depth: 1 }),
           complex_obj_decamelized_one_level_deep
         );
       });
 
       it('converts keys two levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.depascalizeKeys(complexCamelObj, { depth: 2 }),
           complex_obj_decamelized_two_levels_deep
         );
       });
 
       it('converts keys three levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.depascalizeKeys(complexCamelObj, { depth: 3 }),
           complex_obj_decamelized_three_levels_deep
         );
       });
 
       it('converts keys in the entire object four levels deep', function() {
-        assert.deepStrictEqual(
+        assert.deepEqual(
           humps.depascalizeKeys(complexCamelObj, { depth: 4 }),
           complex_obj
         );

--- a/test/test.js
+++ b/test/test.js
@@ -3,29 +3,24 @@ var humps = require('../humps');
 
 describe('humps', function() {
   'use strict';
-  var actual;
 
   // =========
   // = Setup =
   // =========
 
-  beforeEach(function() {
-    this.simple_obj = {
+  var simple_obj = {
       attr_one: 'foo',
       attr_two: 'bar'
-    };
-
-    this.simpleCamelObj = {
+    },
+    simpleCamelObj = {
       attrOne: 'foo',
       attrTwo: 'bar'
-    };
-
-    this.simplePascalObj = {
+    },
+    simplePascalObj = {
       AttrOne: 'foo',
       AttrTwo: 'bar'
-    };
-
-    this.complex_obj = {
+    },
+    complex_obj = {
       attr_one: 'foo',
       attr_two: {
         nested_attr1: 'bar'
@@ -41,9 +36,59 @@ describe('humps', function() {
           }]
         }
       }
-    };
-
-    this.complexCamelObj = {
+    },
+    complex_obj_decamelized_one_level_deep = {
+      attr_one: 'foo',
+      attr_two: {
+        nestedAttr1: 'bar'
+      },
+      attr_three: {
+        nestedAttr2: {
+          nestedAttr3: [{
+            nestedInArray1: 'baz'
+          }, {
+            nestedInArray2: 'hello'
+          }, {
+            nestedInArray3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complex_obj_decamelized_two_levels_deep = {
+      attr_one: 'foo',
+      attr_two: {
+        nested_attr1: 'bar'
+      },
+      attr_three: {
+        nested_attr2: {
+          nestedAttr3: [{
+            nestedInArray1: 'baz'
+          }, {
+            nestedInArray2: 'hello'
+          }, {
+            nestedInArray3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complex_obj_decamelized_three_levels_deep = {
+      attr_one: 'foo',
+      attr_two: {
+        nested_attr1: 'bar'
+      },
+      attr_three: {
+        nested_attr2: {
+          nested_attr3: [{
+            nestedInArray1: 'baz'
+          }, {
+            nestedInArray2: 'hello'
+          }, {
+            nestedInArray3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexCamelObj = {
       attrOne: 'foo',
       attrTwo: {
         nestedAttr1: 'bar'
@@ -59,9 +104,59 @@ describe('humps', function() {
           }]
         }
       }
-    };
-
-    this.complexPascalObj = {
+    },
+    complexObjCamelizedOneLevelDeep = {
+      attrOne: 'foo',
+      attrTwo: {
+        nested_attr1: 'bar'
+      },
+      attrThree: {
+        nested_attr2: {
+          nested_attr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexObjCamelizedTwoLevelsDeep = {
+      attrOne: 'foo',
+      attrTwo: {
+        nestedAttr1: 'bar'
+      },
+      attrThree: {
+        nestedAttr2: {
+          nested_attr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexObjCamelizedThreeLevelsDeep = {
+      attrOne: 'foo',
+      attrTwo: {
+        nestedAttr1: 'bar'
+      },
+      attrThree: {
+        nestedAttr2: {
+          nestedAttr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexPascalObj = {
       AttrOne: 'foo',
       AttrTwo: {
         NestedAttr1: 'bar'
@@ -77,9 +172,59 @@ describe('humps', function() {
           }]
         }
       }
-    };
-
-    this.complexIgnoringNumbersObj = {
+    },
+    complexObjPascalizedOneLevelDeep = {
+      AttrOne: 'foo',
+      AttrTwo: {
+        nested_attr1: 'bar'
+      },
+      AttrThree: {
+        nested_attr2: {
+          nested_attr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexObjPascalizedTwoLevelsDeep = {
+      AttrOne: 'foo',
+      AttrTwo: {
+        NestedAttr1: 'bar'
+      },
+      AttrThree: {
+        NestedAttr2: {
+          nested_attr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexObjPascalizedThreeLevelsDeep = {
+      AttrOne: 'foo',
+      AttrTwo: {
+        NestedAttr1: 'bar'
+      },
+      AttrThree: {
+        NestedAttr2: {
+          NestedAttr3: [{
+            nested_in_array1: 'baz'
+          }, {
+            nested_in_array2: 'hello'
+          }, {
+            nested_in_array3: ['world', 'boo']
+          }]
+        }
+      }
+    },
+    complexIgnoringNumbersObj = {
       attr_one: 'foo',
       attr_two: {
         nested_attr1: 'bar'
@@ -95,9 +240,8 @@ describe('humps', function() {
           }]
         }
       }
-    };
-
-    this.complexCustomObj = {
+    },
+    complexCustomObj = {
       'attr-one': 'foo',
       'attr-two': {
         'nested-attr1': 'bar'
@@ -114,7 +258,6 @@ describe('humps', function() {
         }
       }
     };
-  });
 
   // =========
   // = Specs =
@@ -122,11 +265,15 @@ describe('humps', function() {
 
   describe('.camelizeKeys', function() {
     it('converts simple object keys to camelcase', function() {
-      assert.deepEqual(humps.camelizeKeys(this.simple_obj), this.simpleCamelObj);
+      assert.deepStrictEqual(humps.camelizeKeys(simple_obj), simpleCamelObj);
     });
 
     it('converts complex object keys to camelcase', function() {
-      assert.deepEqual(humps.camelizeKeys(this.complex_obj), this.complexCamelObj);
+      assert.deepStrictEqual(humps.camelizeKeys(complex_obj), complexCamelObj);
+    });
+
+    it('converts complex object keys to camelcase', function() {
+      assert.deepStrictEqual(humps.camelizeKeys(complex_obj), complexCamelObj);
     });
 
     it('does not attempt to process dates', function() {
@@ -138,16 +285,23 @@ describe('humps', function() {
       var convertedObject = {
         aDate: date
       };
-      assert.deepEqual(humps.camelizeKeys(_object), convertedObject);
+      assert.deepStrictEqual(humps.camelizeKeys(_object), convertedObject);
     });
 
     it('converts keys within arrays of objects', function() {
       var array = [{first_name: 'Sam'}, {first_name: 'Jenna'}],
         convertedArray = [{firstName: 'Sam'}, {firstName: 'Jenna'}],
         result = humps.camelizeKeys(array);
-      assert.deepEqual(result, convertedArray);
+      assert.deepStrictEqual(result, convertedArray);
       // Ensure it’s an array, and not an object with numeric keys
-      assert.deepEqual(toString.call(result), '[object Array]');
+      assert.deepStrictEqual(toString.call(result), '[object Array]');
+    });
+
+    it('uses a custom conversion callback', function() {
+      var result = humps.camelizeKeys(simple_obj, function(key, convert) {
+        return key === 'attr_one' ? key : convert(key);
+      });
+      assert.deepStrictEqual(result, { attr_one: 'foo', attrTwo: 'bar' });
     });
 
     describe("when the value is a function", function() {
@@ -159,43 +313,90 @@ describe('humps', function() {
         };
 
         var result = humps.camelizeKeys(_object);
-        // deepEqual treats functions as the same as an empty object
-        assert.strictEqual(result.aFunction, myFunction);
+        assert.deepStrictEqual(result.aFunction, myFunction);
       });
     });
 
-    it('uses a custom convertion callback', function() {
-      actual = humps.camelizeKeys(this.simple_obj, function(key, convert) {
-        return key === 'attr_one' ? key : convert(key);
+    describe("when the depth option is provided", function() {
+      describe("and it is less than 1", function() {
+        it('does not convert anything given a depth of -1', function() {
+          assert.deepStrictEqual(
+            humps.camelizeKeys(complex_obj, { depth: -1 }),
+            complex_obj
+          );
+        });
+
+        it('does not convert anything given a depth of 0', function() {
+          assert.deepStrictEqual(
+            humps.camelizeKeys(complex_obj, { depth: 0 }),
+            complex_obj
+          );
+        });
       });
-      assert.deepEqual(actual, { attr_one: 'foo', attrTwo: 'bar' });
+
+      it('converts keys only on the top level', function() {
+        assert.deepStrictEqual(
+          humps.camelizeKeys(complex_obj, { depth: 1 }),
+          complexObjCamelizedOneLevelDeep
+        );
+      });
+
+      it('converts keys two levels deep', function() {
+        assert.deepStrictEqual(
+          humps.camelizeKeys(complex_obj, { depth: 2 }),
+          complexObjCamelizedTwoLevelsDeep
+        );
+      });
+
+      it('converts keys three levels deep', function() {
+        assert.deepStrictEqual(
+          humps.camelizeKeys(complex_obj, { depth: 3 }),
+          complexObjCamelizedThreeLevelsDeep
+        );
+      });
+
+      it('converts keys in the entire object four levels deep', function() {
+        assert.deepStrictEqual(
+          humps.camelizeKeys(complex_obj, { depth: 4 }),
+          complexCamelObj
+        );
+      });
     });
   });
 
   describe('.decamelizeKeys', function() {
     it('converts simple objects with camelcased keys to underscored', function() {
-      assert.deepEqual(humps.decamelizeKeys(this.simpleCamelObj), this.simple_obj);
+      assert.deepStrictEqual(humps.decamelizeKeys(simpleCamelObj), simple_obj);
     });
 
     it('converts complex objects with camelcased keys to underscored', function() {
-      assert.deepEqual(humps.decamelizeKeys(this.complexCamelObj), this.complex_obj);
+      assert.deepStrictEqual(humps.decamelizeKeys(complexCamelObj), complex_obj);
     });
 
     it('decamelizes keys with a custom separator', function() {
-      actual = humps.decamelizeKeys(this.complexCamelObj, { separator: '-' });
-      assert.deepEqual(actual, this.complexCustomObj);
+      var result = humps.decamelizeKeys(complexCamelObj, { separator: '-' });
+      assert.deepStrictEqual(result, complexCustomObj);
     });
 
     it('uses a custom split regexp', function() {
-      actual = humps.decamelizeKeys({ attr1: 'foo' }, { split: /(?=[A-Z0-9])/ });
-      assert.deepEqual(actual, { attr_1: 'foo' });
+      var result = humps.decamelizeKeys({ attr1: 'foo' }, { split: /(?=[A-Z0-9])/ });
+      assert.deepStrictEqual(result, { attr_1: 'foo' });
     });
 
-    it('uses a custom convertion callback', function() {
-      actual = humps.decamelizeKeys(this.simpleCamelObj, function(key, convert, options) {
+    it('uses a custom conversion callback', function() {
+      var result = humps.decamelizeKeys(simpleCamelObj, function(key, convert, options) {
         return key === 'attrOne' ? key : convert(key, options);
       });
-      assert.deepEqual(actual, { attrOne: 'foo', attr_two: 'bar' });
+      assert.deepStrictEqual(result, { attrOne: 'foo', attr_two: 'bar' });
+    });
+
+    it('uses a custom conversion callback as an option', function() {
+      var result = humps.decamelizeKeys(simpleCamelObj, {
+        process: function(key, convert, options) {
+          return key === 'attrOne' ? key : convert(key, options);
+        }
+      });
+      assert.deepStrictEqual(result, { attrOne: 'foo', attr_two: 'bar' });
     });
 
     describe("when the value is a function", function() {
@@ -207,28 +408,81 @@ describe('humps', function() {
         };
 
         var result = humps.decamelizeKeys(_object);
-        // deepEqual treats functions as the same as an empty object
-        assert.strictEqual(result.a_function, myFunction);
+        assert.deepStrictEqual(result.a_function, myFunction);
       });
     });
 
-    it('uses a custom convertion callback as an option', function() {
-      actual = humps.decamelizeKeys(this.simpleCamelObj, {
-        process: function(key, convert, options) {
-          return key === 'attrOne' ? key : convert(key, options);
-        }
+    describe("when the depth option is provided", function() {
+      describe("and it is less than 1", function() {
+        it('does not convert anything given a depth of -1', function() {
+          assert.deepStrictEqual(
+            humps.decamelizeKeys(complexCamelObj, { depth: -1 }),
+            complexCamelObj
+          );
+        });
+
+        it('does not convert anything given a depth of 0', function() {
+          assert.deepStrictEqual(
+            humps.decamelizeKeys(complexCamelObj, { depth: 0 }),
+            complexCamelObj
+          );
+        });
       });
-      assert.deepEqual(actual, { attrOne: 'foo', attr_two: 'bar' });
+
+      it('converts keys only on the top level', function() {
+        assert.deepStrictEqual(
+          humps.decamelizeKeys(complexCamelObj, { depth: 1 }),
+          complex_obj_decamelized_one_level_deep
+        );
+      });
+
+      it('converts keys two levels deep', function() {
+        assert.deepStrictEqual(
+          humps.decamelizeKeys(complexCamelObj, { depth: 2 }),
+          complex_obj_decamelized_two_levels_deep
+        );
+      });
+
+      it('converts keys three levels deep', function() {
+        assert.deepStrictEqual(
+          humps.decamelizeKeys(complexCamelObj, { depth: 3 }),
+          complex_obj_decamelized_three_levels_deep
+        );
+      });
+
+      it('converts keys in the entire object four levels deep', function() {
+        assert.deepStrictEqual(
+          humps.decamelizeKeys(complexCamelObj, { depth: 4 }),
+          complex_obj
+        );
+      });
+
+      it('converts keys in the entire custom object four levels deep', function() {
+        assert.deepStrictEqual(
+          humps.decamelizeKeys(complexCamelObj, { depth: 4, separator: '-' }),
+          complexCustomObj
+        );
+      });
+
+      it('still works with a custom conversion callback as an option', function() {
+        var result = humps.decamelizeKeys(simpleCamelObj, {
+          depth: 2,
+          process: function(key, convert, options) {
+            return key === 'attrOne' ? key : convert(key, options);
+          }
+        });
+        assert.deepStrictEqual(result, { attrOne: 'foo', attr_two: 'bar' });
+      });
     });
   });
 
   describe('.pascalizeKeys', function() {
     it('converts simple object keys to PascalCase', function() {
-      assert.deepEqual(humps.pascalizeKeys(this.simple_obj), this.simplePascalObj);
+      assert.deepStrictEqual(humps.pascalizeKeys(simple_obj), simplePascalObj);
     });
 
     it('converts complex object keys to PascalCase', function() {
-      assert.deepEqual(humps.pascalizeKeys(this.complex_obj), this.complexPascalObj);
+      assert.deepStrictEqual(humps.pascalizeKeys(complex_obj), complexPascalObj);
     });
 
     it('does not attempt to process dates', function() {
@@ -240,29 +494,121 @@ describe('humps', function() {
       var convertedObject = {
         ADate: date
       };
-      assert.deepEqual(humps.pascalizeKeys(_object), convertedObject);
+      assert.deepStrictEqual(humps.pascalizeKeys(_object), convertedObject);
     });
 
-    it('uses a custom convertion callback', function() {
-      actual = humps.pascalizeKeys(this.simple_obj, function(key, convert) {
+    it('uses a custom conversion callback', function() {
+      var result = humps.pascalizeKeys(simple_obj, function(key, convert) {
         return key === 'attr_one' ? key : convert(key);
       });
-      assert.deepEqual(actual, { attr_one: 'foo', AttrTwo: 'bar' });
+      assert.deepStrictEqual(result, { attr_one: 'foo', AttrTwo: 'bar' });
+    });
+
+    describe("when the depth option is provided", function() {
+      describe("and it is less than 1", function() {
+        it('does not convert anything given a depth of -1', function() {
+          assert.deepStrictEqual(
+            humps.pascalizeKeys(complex_obj, { depth: -1 }),
+            complex_obj
+          );
+        });
+
+        it('does not convert anything given a depth of 0', function() {
+          assert.deepStrictEqual(
+            humps.pascalizeKeys(complex_obj, { depth: 0 }),
+            complex_obj
+          );
+        });
+      });
+
+      it('converts keys only on the top level', function() {
+        assert.deepStrictEqual(
+          humps.pascalizeKeys(complex_obj, { depth: 1 }),
+          complexObjPascalizedOneLevelDeep
+        );
+      });
+
+      it('converts keys two levels deep', function() {
+        assert.deepStrictEqual(
+          humps.pascalizeKeys(complex_obj, { depth: 2 }),
+          complexObjPascalizedTwoLevelsDeep
+        );
+      });
+
+      it('converts keys three levels deep', function() {
+        assert.deepStrictEqual(
+          humps.pascalizeKeys(complex_obj, { depth: 3 }),
+          complexObjPascalizedThreeLevelsDeep
+        );
+      });
+
+      it('converts keys in the entire object four levels deep', function() {
+        assert.deepStrictEqual(
+          humps.pascalizeKeys(complex_obj, { depth: 4 }),
+          complexPascalObj
+        );
+      });
     });
   });
 
   describe('.depascalizeKeys', function() {
     it('converts simple object with PascalCase keys to underscored', function() {
-      assert.deepEqual(humps.depascalizeKeys(this.simplePascalObj), this.simple_obj);
+      assert.deepStrictEqual(humps.depascalizeKeys(simplePascalObj), simple_obj);
     });
 
     it('converts complex object with PascalCase keys to underscored', function() {
-      assert.deepEqual(humps.depascalizeKeys(this.complexPascalObj), this.complex_obj);
+      assert.deepStrictEqual(humps.depascalizeKeys(complexPascalObj), complex_obj);
     });
 
     it('depascalizes keys with a custom separator', function() {
-      actual = humps.depascalizeKeys(this.complexPascalObj, { separator: '-' });
-      assert.deepEqual(actual, this.complexCustomObj);
+      var result = humps.depascalizeKeys(complexPascalObj, { separator: '-' });
+      assert.deepStrictEqual(result, complexCustomObj);
+    });
+
+    describe("when the depth option is provided", function() {
+      describe("and it is less than 1", function() {
+        it('does not convert anything given a depth of -1', function() {
+          assert.deepStrictEqual(
+            humps.depascalizeKeys(complexCamelObj, { depth: -1 }),
+            complexCamelObj
+          );
+        });
+
+        it('does not convert anything given a depth of 0', function() {
+          assert.deepStrictEqual(
+            humps.depascalizeKeys(complexCamelObj, { depth: 0 }),
+            complexCamelObj
+          );
+        });
+      });
+
+      it('converts keys only on the top level', function() {
+        assert.deepStrictEqual(
+          humps.depascalizeKeys(complexCamelObj, { depth: 1 }),
+          complex_obj_decamelized_one_level_deep
+        );
+      });
+
+      it('converts keys two levels deep', function() {
+        assert.deepStrictEqual(
+          humps.depascalizeKeys(complexCamelObj, { depth: 2 }),
+          complex_obj_decamelized_two_levels_deep
+        );
+      });
+
+      it('converts keys three levels deep', function() {
+        assert.deepStrictEqual(
+          humps.depascalizeKeys(complexCamelObj, { depth: 3 }),
+          complex_obj_decamelized_three_levels_deep
+        );
+      });
+
+      it('converts keys in the entire object four levels deep', function() {
+        assert.deepStrictEqual(
+          humps.depascalizeKeys(complexCamelObj, { depth: 4 }),
+          complex_obj
+        );
+      });
     });
   });
 
@@ -296,8 +642,8 @@ describe('humps', function() {
     });
 
     it('decamelizes strings with custom separator', function() {
-      actual = humps.decamelize('helloWorld', { separator: '-' });
-      assert.equal(actual, 'hello-world');
+      var result = humps.decamelize('helloWorld', { separator: '-' });
+      assert.equal(result, 'hello-world');
     });
 
     it('does not separate on digits', function() {


### PR DESCRIPTION
# Add `depth` option

The `depth` option determines how many levels deep in a nested object that keys will be converted.

I also reworked some of the README to make it a bit easier to scan over and make the `options` easier to discover.

This should fully address https://github.com/domchristie/humps/issues/39