### PR TITLE
Improve camelize performance

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -50,11 +50,21 @@
     if (_isNumerical(string)) {
       return string;
     }
-    string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
-      return chr ? chr.toUpperCase() : '';
-    });
-    // Ensure 1st char is always lowercase
-    return string.substr(0, 1).toLowerCase() + string.substr(1);
+
+    var camelizedString = string[0].toLowerCase();
+    var i = 1;
+    var len = string.length;
+    while (i < len) {
+      var currentChar = string[i];
+      if (currentChar === "_" || currentChar === "-" || currentChar === " ") {
+        camelizedString += string[i + 1].toUpperCase();
+        i += 2;
+      } else {
+        camelizedString += currentChar;
+        i++;
+      }
+    }
+    return camelizedString;
   };
 
   var pascalize = function(string) {


### PR DESCRIPTION
I've been building an app for low spec platforms that uses humps to normalize API responses. I noticed that the `camelizeKeys` function was taking nearly hundreds of ms to complete due to `Symbol.replace`. Switching to an iteration-based approach to format the string cut the function time down by more than half for each API call in the app.

Before:
<img width="531" alt="Screen Shot 2021-07-20 at 12 35 17 PM" src="https://user-images.githubusercontent.com/3423707/126363139-127cf6de-7513-4a17-976a-b18845fa1d0b.png">

After:
<img width="453" alt="Screen Shot 2021-07-20 at 12 40 55 PM" src="https://user-images.githubusercontent.com/3423707/126363146-c25b9d77-09ba-45a7-acad-f406d2fa8bc7.png">




