### PR TITLE
Fix decamelize function with numbers present in the string

### DIFF
--- a/humps.js
+++ b/humps.js
@@ -41,7 +41,7 @@
   var separateWords = function(string, options) {
     options = options || {};
     var separator = options.separator || '_';
-    var split = options.split || /(?=[A-Z])/;
+    var split = options.split || /(?=[A-Z])|(\d+)/;
 
     return string.split(split).join(separator);
   };


### PR DESCRIPTION
### ISSUE

When `decamelizing` a string with numbers present, the numbers are not separated by a separator.

```js
'per1Day'.split(/(?=[A-Z])/).join('_').toLowercase()
// results in per1_day
```

### PROPOSAL

A number in a string should be treated like a standalone entity.

```js
'per1Day'.split(/(?=[A-Z])|(\d+)/).join('_').toLowercase()
// results in per_1_day
```